### PR TITLE
Remove all. Use parent class getter.

### DIFF
--- a/src/KeyValueStore.js
+++ b/src/KeyValueStore.js
@@ -11,10 +11,6 @@ class KeyValueStore extends Store {
     this._type = 'keyvalue'
   }
 
-  all () {
-    return this._index._index
-  }
-
   get (key) {
     return this._index.get(key)
   }


### PR DESCRIPTION
all() method is blocking Store parent class' all getter. Use parent's all getter to retrieve all key/value pairs.