### PR TITLE
fix:restoring all function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-kvstore",
-  "version": "1.5.0-rc2",
+  "version": "1.5.0-rc3",
   "description": "Key-Value Store for orbit-db",
   "main": "src/KeyValueStore.js",
   "homepage":"https://github.com/orbitdb/orbit-db-kvstore",

--- a/src/KeyValueStore.js
+++ b/src/KeyValueStore.js
@@ -11,6 +11,10 @@ class KeyValueStore extends Store {
     this._type = 'keyvalue'
   }
 
+  all () {
+    return this._index._index
+  }
+
   get (key) {
     return this._index.get(key)
   }

--- a/src/KeyValueStore.js
+++ b/src/KeyValueStore.js
@@ -11,7 +11,7 @@ class KeyValueStore extends Store {
     this._type = 'keyvalue'
   }
 
-  all () {
+  get all () {
     return this._index._index
   }
 


### PR DESCRIPTION
This PR restores the `all` functionality for compatibility as people can now also call `db.index` to retrieve the index of a kvstore.