### PR TITLE
Interface-datastore compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "interface-datastore": "^0.8.1",
     "orbit-db-store": "~3.1.0"
   },
   "localMaintainers": [

--- a/src/KeyValueStore.js
+++ b/src/KeyValueStore.js
@@ -2,6 +2,8 @@
 
 const Store = require('orbit-db-store')
 const KeyValueIndex = require('./KeyValueIndex')
+const {Key, utils} = require('interface-datastore')
+const {filter, sortAll, take, map} = utils
 
 class KeyValueStore extends Store {
   constructor(ipfs, id, dbname, options) {
@@ -16,27 +18,89 @@ class KeyValueStore extends Store {
   }
 
   get (key) {
-    return this._index.get(key)
+    return this._index.get(key.toString())
   }
 
   set (key, data, options = {}) {
-    return this.put(key, data, options)
+    return this.put(key.toString(), data, options)
   }
 
   put (key, data, options = {}) {
     return this._addOperation({
       op: 'PUT',
-      key: key,
+      key: key.toString(),
       value: data
     }, options)
   }
-
   del (key, options = {}) {
     return this._addOperation({
       op: 'DEL',
-      key: key,
+      key: key.toString(),
       value: null
     }, options)
+  }
+
+  /**
+   * Query datastore via async iterable
+   * NOTE: In compliance with interface-datastore specifications. Backwards compatible (without leading /) orbit-db keyvalues may not work as expected.
+   * @param {Object} q 
+   */
+  query (q) {
+    let it = Object.entries(this._index._index)
+
+    it = map(it, entry => ({ key: new Key(entry[0]), value: entry[1] }))
+
+    if (q.prefix != null) {
+      it = filter(it, e => e.key.toString().startsWith(q.prefix))
+    }
+
+    if (Array.isArray(q.filters)) {
+      it = q.filters.reduce((it, f) => filter(it, f), it)
+    }
+
+    if (Array.isArray(q.orders)) {
+      it = q.orders.reduce((it, f) => sortAll(it, f), it)
+    }
+
+    if (q.offset != null) {
+      let i = 0
+      it = filter(it, () => i++ >= q.offset)
+    }
+
+    if (q.limit != null) {
+      it = take(it, q.limit)
+    }
+
+    if (q.keysOnly === true) {
+      it = map(it, e => ({ key: e.key }))
+    }
+
+    return it
+  }
+  batch () {
+    let puts = []
+    let dels = []
+
+    return {
+      put (key, value) {
+        puts.push([key, value])
+      },
+      delete (key) {
+        dels.push(key)
+      },
+      commit: async () => { // eslint-disable-line require-await
+        //Future add support for multiples operations per oplog entry.
+        puts.forEach(v => {
+          await this.put(v[0], v[1])
+        })
+        puts = []
+
+        dels.forEach(key => {
+          await this.del(key)
+        })
+        dels = []
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### What this PR adds

- `Query()` method as diagrammed in `interface-datastore`
- `Batch()` method as diagrammed in `interface-datastore`
- Backwards compatible support for `interface-datastore` Key Object. (Open to additional discussion).

What this PR does not add
- Async compliance
- Method naming compliance (ex del)

### Reasoning

Adding the query method is absolutely necessary for applications developers wanting to query key-values with or without a particular prefix. There is currently no API in kvstore that does anything similar. Discovering keys or routinely processing the entire store is not possible with the current API. However, there is an in memory index that can be queried no different than a normal javascript object. This works! But there is no guarantee that the same logic can be provided with different indexes down the road. Using a disk backed index cannot provide the same level of access for example. 

I believe adding batch method is necessary for future changes. For example supporting modifying multiple key-value records inside a single oplog entry. Currently batch method commits modifications in multiple oplog entries, this is left open to future implementation modifications supporting multi key-value modification inside a single oplog entry.

By having a solid, well established common interface providing the same API level functionality regardless of implementation, I believe is key to long term utilization

I am open to further discussion on implementation, or alternatives approaches.
