### PR TITLE
Added `applyEntry` function to Index.

### DIFF
--- a/src/KeyValueIndex.js
+++ b/src/KeyValueIndex.js
@@ -8,6 +8,14 @@ class KeyValueIndex {
   get(key) {
     return this._index[key]
   }
+  
+  applyEntry(entry) {
+    if(item.payload.op === "PUT") {
+      this._index[entry.payload.key] = item.payload.value
+    } else if(item.payload.op === "DEL") {
+      delete this._index[item.payload.key] 
+    }
+  }
 
   updateIndex(oplog) {
     oplog.values
@@ -16,11 +24,7 @@ class KeyValueIndex {
       .reduce((handled, item) => {
         if(!handled.includes(item.payload.key)) {
           handled.push(item.payload.key)
-          if(item.payload.op === 'PUT') {
-            this._index[item.payload.key] = item.payload.value
-          } else if(item.payload.op === 'DEL') {
-            delete this._index[item.payload.key]
-          }
+          this.applyEntry(item)
         }
         return handled
       }, [])


### PR DESCRIPTION
I implemented this function because I want it to be easier to customize validation
of entries without modifying or knowing about the internal data structure used
in the KVStore. 

If this PR is merged I plan on implementing similar functions on the DocStore, FeedStore and EventLog.

I think it is important for OrbitDB to be easily customizable and this feature should
lower the effort for customizing validation significantly.

In it's current form, the `applyEntry` function is not a breaking change, but an added
pattern that can be used to ease the customization efforts of Stores.

If this pattern is implemented I also feel ready to finally finish [Part 5 of the Field Manual](https://github.com/orbitdb/field-manual/blob/main/05_Customizing_OrbitDB/06_AccessControllers.md) by introducing this pattern and implementing moderation rules using it.

Thanks for your consideration!

### Custom Validation of Entries on the KeyValueIndex
To create a custom validation of the Index using the `applyEntry` function:
```js
const KeyValueIndex = require("orbit-db-kvstore/src/KeyValueIndex")

// An index that only allows a key to be added iff it hasn't been added before.
class Index extends KeyValueIndex {
      applyEntry(entry) {
           if(entry.payload.op === "PUT" && this._index[entry.payload.key] === undefined) {
                super().applyEntry(entry) // or: this._index[entry.payload.key] = entry.payload.value
           }
      }
}
```