### PR TITLE
[perf] optimise key index

### DIFF
--- a/src/KeyValueIndex.js
+++ b/src/KeyValueIndex.js
@@ -10,22 +10,22 @@ class KeyValueIndex {
   }
 
   updateIndex(oplog) {
-    const values = oplog.values;
+    const values = oplog.values
 
-    const handled = {};
+    const handled = {}
     for (let i = values.length - 1; i >= 0; i--) {
-      const item = values[i];
+      const item = values[i]
       if (handled[item.payload.key]) {
-        return;
+        return
       }
-      handled[item.payload.key] = true;
+      handled[item.payload.key] = true
       if (item.payload.op === 'PUT') {
-        this._index[item.payload.key] = item.payload.value;
-        return;
+        this._index[item.payload.key] = item.payload.value
+        return
       }
       if (item.payload.op === 'DEL') {
-        delete this._index[item.payload.key];
-        return;
+        delete this._index[item.payload.key]
+        return
       }
     }
   }

--- a/src/KeyValueIndex.js
+++ b/src/KeyValueIndex.js
@@ -10,20 +10,24 @@ class KeyValueIndex {
   }
 
   updateIndex(oplog) {
-    oplog.values
-      .slice()
-      .reverse()
-      .reduce((handled, item) => {
-        if(!handled.includes(item.payload.key)) {
-          handled.push(item.payload.key)
-          if(item.payload.op === 'PUT') {
-            this._index[item.payload.key] = item.payload.value
-          } else if(item.payload.op === 'DEL') {
-            delete this._index[item.payload.key]
-          }
-        }
-        return handled
-      }, [])
+    const values = oplog.values;
+
+    const handled = {};
+    for (let i = values.length - 1; i >= 0; i--) {
+      const item = values[i];
+      if (handled[item.payload.key]) {
+        return;
+      }
+      handled[item.payload.key] = true;
+      if (item.payload.op === 'PUT') {
+        this._index[item.payload.key] = item.payload.value;
+        return;
+      }
+      if (item.payload.op === 'DEL') {
+        delete this._index[item.payload.key];
+        return;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
There are two avenues for optimisation here: 

1. There is no need for a reversal and subsequently a copy of the original `oplog.values` array since this can be handled by a reverse for loop.
2. Mainly, the `handled` value instead of being an array it can be an object, resulting in O(1) searches for handled values, instead of having to run a linear search each time an oplog value is added (which actually makes the creation of the index O(1/2 n^2 (n + 1)) - Ι think...)

