### PR TITLE
[fix] fix keystore index regression

### DIFF
--- a/src/KeyValueIndex.js
+++ b/src/KeyValueIndex.js
@@ -16,16 +16,16 @@ class KeyValueIndex {
     for (let i = values.length - 1; i >= 0; i--) {
       const item = values[i]
       if (handled[item.payload.key]) {
-        return
+        continue
       }
       handled[item.payload.key] = true
       if (item.payload.op === 'PUT') {
         this._index[item.payload.key] = item.payload.value
-        return
+        continue
       }
       if (item.payload.op === 'DEL') {
         delete this._index[item.payload.key]
-        return
+        continue
       }
     }
   }


### PR DESCRIPTION
My previous PR #48, broke the index, because I mistakenly used `return` instead of `continue`. This PR fixes that.

This was an obvious mistake from my part, sorry 😅